### PR TITLE
Use NMEA Timestamp to play logs at real time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Commandline options:
 
   -r # | --repeat=# - optional number of times to reread input file. Any valid port is accepted.
 
-  -s #.# | --sleep=#.# - optional seconds delay between packets. Default is 0.1 seconds.
+  -s #.# | --sleep=#.# - optional seconds delay between packets, when there is no timestamp in NMEA packets. Default is 0.1 seconds.
+
+  -f #.# | --fast=#.# - optional speed acceleration factor if NMEAv4. Default factor is 1.0.
 
   -t, --TCP - create TCP server on primary IP address.  Specify any IP address using --host option to override default.
 

--- a/VDRplayer.py
+++ b/VDRplayer.py
@@ -96,7 +96,12 @@ def delayMessage(mess, Delay, Speed):
             starttime = time.time()
             initialdelta = starttime - messtime
         ComputedDelay = messtime + initialdelta - Speed * time.time() + (Speed - 1 ) * starttime
-        if ComputedDelay > 0:
+        if ComputedDelay > 60 :
+            print("Huge gap in file. Not waiting %d seconds." % ComputedDelay)
+            starttime = time.time()
+            initialdelta = starttime - messtime
+            ComputedDelay = 1
+        if ComputedDelay > 0 :
             time.sleep(ComputedDelay)
 # End getMessageTimestamp()
 

--- a/VDRplayer.py
+++ b/VDRplayer.py
@@ -72,7 +72,8 @@ def getNextMessage(f, Delay, Speed):
         return False
     # End if
     mess = mess.strip()
-    delayMessage(mess, Delay, Speed)
+    if Delay > 0:
+        delayMessage(mess, Delay, Speed)
     mess = mess + u"\r\n"
     return(mess.encode("utf-8"))
 # End getNextMessage()
@@ -86,8 +87,7 @@ def delayMessage(mess, Delay, Speed):
     try: 
        messtime = int(mess.split("*")[0].split(":")[2])
     except:
-        if Delay > 0:
-            time.sleep(Delay)
+        time.sleep(Delay)
     else:
         try:
             initialdelta
@@ -100,7 +100,7 @@ def delayMessage(mess, Delay, Speed):
             print("Huge gap in file. Not waiting %d seconds." % ComputedDelay)
             starttime = time.time()
             initialdelta = starttime - messtime
-            ComputedDelay = 1
+            ComputedDelay = 0 
         if ComputedDelay > 0 :
             time.sleep(ComputedDelay)
 # End getMessageTimestamp()


### PR DESCRIPTION
This is an evolution that rely on NMEAv4 TAG timestamp (when present) to play logfile at real speed.
The ‘-s’ option in that case can accelerate or decelerate the play speed.